### PR TITLE
spacy 3.5.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,9 @@ test:
     - spacy
   commands:
     - pip check
-    - python -m pytest --tb=native --pyargs {{ name }}
+    # Skip test_find_available_port on osx-arm64 because of 'ValueError: [E1050] Port 5000 is already in use.'
+    - python -m pytest --tb=native --pyargs {{ name }} -k "not test_find_available_port"  # [osx and arm64]
+    - python -m pytest --tb=native --pyargs {{ name }}  # [not (osx and arm64)]
 
 about:
   home: https://spacy.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,9 +45,7 @@ requirements:
     - catalogue >=2.0.6,<2.1.0
     - spacy-loggers >=1.0.0,<2.0.0
     # Exclude typer with unpinned click (>=0.3.2)
-    - typer >=0.3.2,<0.5.0
-    # Exclude newer click due to typer issues
-    - click <8.1.0
+    - typer >=0.3.0,<0.8.0
     - pathy >=0.10.0
     - smart_open >=5.2.1,<7.0.0
     # Third-party dependencies

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "spacy" %}
-{% set version = "3.5.2" %}
+{% set version = "3.5.3" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 22c1ffaab285b7477003d4b5b038414cc32468a690d479015b9a698c531c813b
+  sha256: 35971d6721576538d6c423c66a09ce00bf66e10e40726a57b7a81993180c248c
 
 build:
   number: 0
@@ -54,7 +54,8 @@ requirements:
     - tqdm >=4.38.0,<5.0.0
     - {{ pin_compatible('numpy') }}
     - requests >=2.13.0,<3.0.0
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.11.0
+    # Exclude pydantic 1.8.2 due to issues with python 3.11
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,!=1.8.2,<1.11.0
     - jinja2
     - langcodes >=3.2.0,<4.0.0
     # Official Python utilities

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "spacy" %}
-{% set version = "3.3.1" %}
+{% set version = "3.5.2" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 7f87dbdb104d851ae6ba5fd3a76a2e14e22e048135903e98baf08571a3aa81c0
+  sha256: 22c1ffaab285b7477003d4b5b038414cc32468a690d479015b9a698c531c813b
 
 build:
-  number: 1
+  number: 0
   # no s390x support
-  # spacy 3.3.1 isn't compatible with python 3.11. Only `spacy >=3.4.2` has that support, see https://github.com/explosion/spaCy/issues/11664#issuecomment-1285770573
-  skip: True  # [py<36 or py>=311 or (linux and s390x)]
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  skip: True  # [py<36 or (linux and s390x)]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - spacy = spacy.cli:setup_cli
 
@@ -25,44 +24,43 @@ requirements:
     - python
     - cymem 2.0.6
     - cython 0.29.32
-    - cython-blis 0.7.7
     - murmurhash 1.0.7
     - numpy {{ numpy }}
     - pathy 0.10.1
     - pip
     - preshed 3.0.6
     - setuptools
-    - thinc 8.0.15
+    - thinc 8.1.10
     - wheel
   run:
     - python
     # Spacy libraries
-    - spacy-legacy >=3.0.9,<3.1.0
+    - spacy-legacy >=3.0.11,<3.1.0
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
-    - thinc >=8.0.14,<8.1.0
-    - cython-blis >=0.4.0,<0.8.0
-    - wasabi >=0.9.1,<1.1.0
+    - thinc >=8.1.8,<8.2.0
+    - wasabi >=0.9.1,<1.2.0
     - srsly >=2.4.3,<3.0.0
     - catalogue >=2.0.6,<2.1.0
     - spacy-loggers >=1.0.0,<2.0.0
-    # Exclude typer with unpinned click
-    - typer >=0.3.0,<0.5.0
+    # Exclude typer with unpinned click (>=0.3.2)
+    - typer >=0.3.2,<0.5.0
     # Exclude newer click due to typer issues
     - click <8.1.0
-    - pathy >=0.3.5
+    - pathy >=0.10.0
+    - smart_open >=5.2.1,<7.0.0
     # Third-party dependencies
     - tqdm >=4.38.0,<5.0.0
     - {{ pin_compatible('numpy') }}
     - requests >=2.13.0,<3.0.0
-    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.9.0
+    - pydantic >=1.7.4,!=1.8,!=1.8.1,<1.11.0
     - jinja2
     - langcodes >=3.2.0,<4.0.0
     # Official Python utilities
     - setuptools
     - packaging >=20.0
-    - typing_extensions >=3.7.4.1,<4.2.0  # [py<=37]
+    - typing_extensions >=3.7.4.1,<4.5.0  # [py<38]
 
 test:
   requires:
@@ -75,9 +73,7 @@ test:
     - spacy
   commands:
     - pip check
-    # Skip tests on osx-arm64 for v4.10.0 due to 
-    # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xea in position 137: invalid continuation byte
-    - python -m pytest --tb=native --pyargs {{ name }}  # [not (osx and arm64)]
+    - python -m pytest --tb=native --pyargs {{ name }}
 
 about:
   home: https://spacy.io/


### PR DESCRIPTION
Changelog: https://github.com/explosion/spaCy/releases
License: https://github.com/explosion/spaCy/blob/v3.5.3/LICENSE
Requirements:
- https://github.com/explosion/spaCy/blob/v3.5.3/pyproject.toml
- https://github.com/explosion/spaCy/blob/v3.5.3/requirements.txt
- https://github.com/explosion/spaCy/blame/v3.5.3/setup.cfg
- https://github.com/explosion/spaCy/blob/v3.5.3/setup.py

Actions:
1. Reset the build number
2. Add --no-build-isolation to script
3. Remove `cython-blis` from `host` and `run` because the upstream source dropped this dependency before **v3.4.2** https://github.com/conda-forge/spacy-feedstock/commit/0c36f0a4fe6c09a6784d32a058df62ba853a1a31
4. Pin `thinc` to `8.1.10` in `host`
5. Update run pinnings
6. Exclude `pydantic 1.8.2` due to issues with Python 3.11
7. Update pytest command: Skip `test_find_available_port` on `osx-arm64` because '`ValueError: [E1050] Port 5000 is already in use`.'