### PR TITLE
spacy 3.8.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,3 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/ff3408c
+  - https://staging.continuum.io/prefect/fs/thinc-feedstock/pr17/10d277f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,4 @@
 channels:
   - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/a90ed26
   - https://staging.continuum.io/prefect/fs/thinc-feedstock/pr17/1c1b99a
+  - https://staging.continuum.io/prefect/fs/cython-feedstock/pr22/595cc65

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,3 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/ff3408c
-  - https://staging.continuum.io/prefect/fs/thinc-feedstock/pr17/10d277f
+  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/a90ed26
+  - https://staging.continuum.io/prefect/fs/thinc-feedstock/pr17/1c1b99a

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/cython-blis-feedstock/pr6/a90ed26
-  - https://staging.continuum.io/prefect/fs/thinc-feedstock/pr17/1c1b99a
-  - https://staging.continuum.io/prefect/fs/cython-feedstock/pr22/595cc65

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-cxx_compiler:    # [win]
-  - vs2019       # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - numpy >=2.0.0,<2.1.0
     - setuptools
     - wheel
-    - cython >=0.25,<3.0
+    - cython 3
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
@@ -52,7 +52,7 @@ requirements:
     - weasel >=0.1.0,<0.5.0
     # Third-party dependencies
     - numpy >=2.0.0
-    - tqdm >=4.38.0,<5.0.0
+    - tqdm >=4.,<3.038.0,<5.0.0
     - requests >=2.13.0,<3.0.0
     # Exclude pydantic 1.8.2 due to issues with python 3.11
     - pydantic >=1.7.4,!=1.8,!=1.8.1,!=1.8.2,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - numpy >=2.0.0,<2.1.0
     - setuptools
     - wheel
-    - cython 3
+    - cython
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - numpy >=2.0.0,<2.1.0
     - setuptools
     - wheel
-    - cython
+    - cython >=0.25,<3.0
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - weasel >=0.1.0,<0.5.0
     # Third-party dependencies
     - numpy >=2.0.0
-    - tqdm >=4.,<3.038.0,<5.0.0
+    - tqdm >=4.38.0,<5.0.0
     - requests >=2.13.0,<3.0.0
     # Exclude pydantic 1.8.2 due to issues with python 3.11
     - pydantic >=1.7.4,!=1.8,!=1.8.1,!=1.8.2,<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "spacy" %}
-{% set version = "3.7.2" %}
+{% set version = "3.8.2" %}
 
 package:
   name: {{ name }}
@@ -7,14 +7,15 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cedf4927bf0d3fec773a6ce48d5d2c91bdb02fed3c7d5ec07bdb873f1126f1a0
+  sha256: 4b37ebd25ada4059b0dc9e0893e70dde5df83485329a068ef04580e70892a65d
   patches:
     - patches/0001-skip-beam-density-test.patch
 
 build:
   number: 0
   # no s390x support
-  skip: True  # [py<36 or s390x]
+  # no python <3.9 support because of numpy >=2
+  skip: True  # [py<39 or s390x]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - spacy = spacy.cli:setup_cli
@@ -27,14 +28,14 @@ requirements:
   host:
     - pip
     - python
-    - numpy {{ numpy }}
+    - numpy >=2.0.0,<2.1.0
     - setuptools
     - wheel
     - cython >=0.25,<3.0
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
-    - thinc >=8.1.8,<8.3.0
+    - thinc >=8.3.0,<8.4.0
   run:
     - python
     # Spacy libraries
@@ -42,16 +43,15 @@ requirements:
     - murmurhash >=0.28.0,<1.1.0
     - cymem >=2.0.2,<2.1.0
     - preshed >=3.0.2,<3.1.0
-    - thinc >=8.1.8,<8.3.0
+    - thinc >=8.3.0,<8.4.0
     - wasabi >=0.9.1,<1.2.0
     - srsly >=2.4.3,<3.0.0
     - catalogue >=2.0.6,<2.1.0
     - spacy-loggers >=1.0.0,<2.0.0
     - typer >=0.3.0,<0.10.0
-    - weasel >=0.1.0,<0.4.0
+    - weasel >=0.1.0,<0.5.0
     # Third-party dependencies
-    - {{ pin_compatible('numpy') }}
-    - smart_open >=5.2.1,<7.0.0
+    - numpy >=2.0.0
     - tqdm >=4.38.0,<5.0.0
     - requests >=2.13.0,<3.0.0
     # Exclude pydantic 1.8.2 due to issues with python 3.11
@@ -61,7 +61,6 @@ requirements:
     # Official Python utilities
     - setuptools
     - packaging >=20.0
-    - typing_extensions >=3.7.4.1,<4.5.0  # [py<38]
   run_constrained:
     - spacy-transformers >=1.1.2,<1.4.0
 


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5891](https://anaconda.atlassian.net/browse/PKG-5891) 
- [Upstream repository](https://github.com/explosion/spaCy/tree/release-v3.8.2)
- Requirements:
  - https://github.com/explosion/spaCy/blob/release-v3.8.2/pyproject.toml
  - https://github.com/explosion/spaCy/blob/release-v3.8.2/setup.cfg 
  - https://github.com/explosion/spaCy/blob/release-v3.8.2/setup.py

### Explanation of changes:

- Skip python <3.9 because of numpy >=2
- Do not use `{{ pin_compatible('numpy') }}` in `run` because it will pick up an incompatible numpy 1.2x
- Update dependencies and pinnings

### Notes:

- It requires updating:
  - https://github.com/AnacondaRecipes/cython-blis-feedstock/pull/6
  - https://github.com/AnacondaRecipes/thinc-feedstock/pull/17
  - https://github.com/AnacondaRecipes/cython-feedstock/pull/22

[PKG-5891]: https://anaconda.atlassian.net/browse/PKG-5891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ